### PR TITLE
(fix): remove extra space

### DIFF
--- a/andes-demo.yml
+++ b/andes-demo.yml
@@ -47,7 +47,7 @@ services:
       - velastic:/usr/share/elasticsearch/data
     ports:
       - "9200:9200"   
-  andes_nginx:
+ andes_nginx:
     container_name: andes_nginx
     image: nginx
     volumes:

--- a/andes-demo.yml
+++ b/andes-demo.yml
@@ -1,7 +1,7 @@
 version: '2'
 
 services:
- vapp:
+ andes_vapp:
   image: andesnqn/vapp
   container_name: andes_app
   ports:


### PR DESCRIPTION
Remove an additional space to solve a conflict with new versions of docker-compose and yaml parser.

EDIT:
*vapp* service from andes-demo.yml was renamed to *andes_vapp* because nginx.conf had conflict with the host

Andes is awesome! :smiley: 